### PR TITLE
fix: dialog note blur

### DIFF
--- a/src/components/Dialog-Window/Notes/DialogNote.module.scss
+++ b/src/components/Dialog-Window/Notes/DialogNote.module.scss
@@ -9,10 +9,12 @@ form {
   width: 100%;
   font-size: inherit;
   font-family: inherit;
+  line-height: 1.4;
   border: none;
   outline: none;
   flex-grow: 1;
   padding: 0.5rem;
+  overflow-y: scroll;
 }
 
 .dynamicSavingText,
@@ -25,7 +27,6 @@ form {
   border-radius: 0.25rem;
   display: flex;
   flex-direction: column;
-  overflow: auto;
   height: 100%;
   position: relative;
   top: 0.5rem;


### PR DESCRIPTION
When the textarea in the note is full, sometimes the text gets blurry on certain dialog/screen widths. To avoid this we move the overflow and make sure it only applies to the textarea and vertically.

<img width="636" alt="Skjermbilde 2023-06-28 kl  10 19 48" src="https://github.com/NDLANO/h5p-topic-map/assets/35261194/d1cc3775-f08d-41cb-965a-01d01218acef">
(Difficult to see, but tested in Chrome on Mac)

Also it is good to ensure enough line-height for the text within the textarea. 