### PR TITLE
fix: avoid tablist in dialog when only one item

### DIFF
--- a/src/components/Dialog-Window/Tabs/DialogTabs.tsx
+++ b/src/components/Dialog-Window/Tabs/DialogTabs.tsx
@@ -31,37 +31,31 @@ const useItemInfo = (item: CommonItemType): {
 } => {
   const { description, topicImage, dialog } = item;
 
+  if (!dialog) {
+    return {
+      hasText: false,
+      hasLinks: false,
+      hasVideo: false,
+      hasAudio: false,
+      showNote: false,
+      showTabs: false,
+    };
+  }
+
   const smallScreen = useMedia('(max-width: 768px)');
-  const hasNote = (item.dialog?.hasNote && smallScreen) ?? false;
-  const showNote = hasNote && smallScreen;
+  const showNote = dialog.hasNote && smallScreen;
 
-  const hasText = !!(dialog?.text || topicImage || description);
+  const hasText = !!(dialog.text || topicImage || description);
   const hasLinks =
-    !!((dialog?.links &&
-      dialog?.links?.filter((link) => Boolean(link.url)).length > 0) ||
-      dialog?.showAddLinks);
-  const hasVideo = !!(dialog?.video?.[0]?.path);
-  const hasAudio = !!(dialog?.audio?.audioFile?.[0]?.path);
-
-  let content = 0;
-  if (hasText) {
-    content++;
-  }
-  if (hasLinks) {
-    content++;
-  }
-  if (hasVideo) {
-    content++;
-  }
-  if (hasAudio) {
-    content++;
-  }
-  if (showNote) {
-    content++;
-  }
+    !!((dialog.links &&
+      dialog.links?.filter((link) => Boolean(link.url)).length > 0) ||
+      dialog.showAddLinks);
+  const hasVideo = !!(dialog.video?.[0]?.path);
+  const hasAudio = !!(dialog.audio?.audioFile?.[0]?.path);
 
   // Only show tabs if there is more than one item to choose from
-  const showTabs = content > 1;
+  const numberOfContentItems = [hasText, hasLinks, hasVideo, hasAudio, showNote].filter(Boolean).length;
+  const showTabs = numberOfContentItems > 1;
 
   return {
     hasText,
@@ -225,7 +219,7 @@ export const DialogTabs: React.FC<TabProps> = ({ item }) => {
       defaultValue={defaultTabValue(item)}
       orientation="horizontal"
     >
-      {showTabs ? (
+      {showTabs && (
         <List
           className={showTabs ? styles.list : ''}
           aria-label={t('dialogTabListAriaLabel')}
@@ -237,18 +231,18 @@ export const DialogTabs: React.FC<TabProps> = ({ item }) => {
             </Trigger>
           ) : null}
         </List>
-      ) : null}
+      )}
       <div
         className={`${styles.tabItemWrapper} ${!showTabs ? styles.marginTop : ''
         }`}
       >
         {dialogContent(item)}
-        {showNote ? (showTabs ? (
+        {showNote && (showTabs ? (
           <Content key="notes" value="notes" className={styles.noteWrapper}>
             {dialogNote}
           </Content>) : (
           dialogNote
-        )) : null}
+        ))}
       </div>
     </Root>
   );

--- a/src/components/Dialog-Window/Tabs/DialogTabs.tsx
+++ b/src/components/Dialog-Window/Tabs/DialogTabs.tsx
@@ -21,7 +21,7 @@ type Translation = {
   text: string;
 };
 
-const getItemInfo = (item: CommonItemType): {
+const useItemInfo = (item: CommonItemType): {
   hasText: boolean;
   hasLinks: boolean;
   hasVideo: boolean;
@@ -35,29 +35,29 @@ const getItemInfo = (item: CommonItemType): {
   const hasNote = (item.dialog?.hasNote && smallScreen) ?? false;
   const showNote = hasNote && smallScreen;
 
-  const hasText = (dialog?.text || topicImage || description) ? true : false;
+  const hasText = !!(dialog?.text || topicImage || description);
   const hasLinks =
-    ((dialog?.links &&
+    !!((dialog?.links &&
       dialog?.links?.filter((link) => Boolean(link.url)).length > 0) ||
-      dialog?.showAddLinks) ? true : false;
-  const hasVideo = (dialog?.video?.[0]?.path) ? true : false;
-  const hasAudio = (dialog?.audio?.audioFile?.[0]?.path) ? true : false;
+      dialog?.showAddLinks);
+  const hasVideo = !!(dialog?.video?.[0]?.path);
+  const hasAudio = !!(dialog?.audio?.audioFile?.[0]?.path);
 
-  var content = 0;
+  let content = 0;
   if (hasText) {
-    content++; 
+    content++;
   }
   if (hasLinks) {
-    content++; 
+    content++;
   }
   if (hasVideo) {
-    content++; 
+    content++;
   }
   if (hasAudio) {
-    content++; 
+    content++;
   }
   if (showNote) {
-    content++; 
+    content++;
   }
 
   // Only show tabs if there is more than one item to choose from
@@ -95,7 +95,7 @@ const tabLabelItems = (
   item: CommonItemType,
   translation: Translation,
 ): JSX.Element[] => {
-  const { hasText, hasLinks, hasVideo, hasAudio } = getItemInfo(item);
+  const { hasText, hasLinks, hasVideo, hasAudio } = useItemInfo(item);
   const items = [];
 
   hasText
@@ -131,7 +131,7 @@ const tabLabelItems = (
 
 const dialogContent = (item: CommonItemType): JSX.Element[] => {
   const { id, description, topicImage, topicImageAltText, dialog } = item;
-  const { hasText, hasLinks, hasVideo, hasAudio, showTabs } = getItemInfo(item);
+  const { hasText, hasLinks, hasVideo, hasAudio, showTabs } = useItemInfo(item);
   const items: JSX.Element[] = [];
 
   // Dialog text
@@ -202,7 +202,7 @@ const dialogContent = (item: CommonItemType): JSX.Element[] => {
 
 export const DialogTabs: React.FC<TabProps> = ({ item }) => {
   const { t } = useTranslation();
-  const { showNote, showTabs } = getItemInfo(item);
+  const { showNote, showTabs } = useItemInfo(item);
 
   const translation: Translation = {
     audio: t('copyrightAudio'),

--- a/src/components/Dialog-Window/Tabs/DialogTabs.tsx
+++ b/src/components/Dialog-Window/Tabs/DialogTabs.tsx
@@ -223,7 +223,7 @@ export const DialogTabs: React.FC<TabProps> = ({ item }) => {
     <Root
       className={styles.tabs}
       defaultValue={defaultTabValue(item)}
-      orientation="vertical"
+      orientation="horizontal"
     >
       {showTabs ? (
         <List


### PR DESCRIPTION
Avoid using `tablist` and `tabpanel` when there is only one modal item to show. Refactor so that `List` and `Content` are not used for those instances. 