### PR TITLE
feat: improve accessibility of modals - notes

### DIFF
--- a/language/.en.json
+++ b/language/.en.json
@@ -409,7 +409,7 @@
         },
         {
           "label": "Navbar notes section body",
-          "default": "Here you have an overview of all the notes you have written. The notes are saved locally in this browser. To save the notes elsewhere, you can print or copy the notes into a document."
+          "default": "This is an overview of your notes. They are saved locally in this browser. You can either print or copy the notes into a document."
         },
         {
           "label": "Navbar notes print button label",

--- a/language/es-MX.json
+++ b/language/es-MX.json
@@ -409,7 +409,7 @@
         },
         {
           "label": "Cuerpo de la sección de notas de la barra de navegación",
-          "default": "Aquí tiene un resumen de todas las notas que ha escrito. Las notas se guardan localmente en este navegador. Para guardar las notas en otro lugar, puede imprimir o copiar las notas en un documento."
+          "default": "This is an overview of your notes. They are saved locally in this browser. You can either print or copy the notes into a document."
         },
         {
           "label": "Etiqueta del botón de impresión de notas de la barra de navegación",

--- a/language/es.json
+++ b/language/es.json
@@ -409,7 +409,7 @@
         },
         {
           "label": "Cuerpo de la sección de notas de la barra de navegación",
-          "default": "Aquí tienes un resumen de todas las notas que has escrito. Las notas se guardan localmente en este navegador. Para guardar las notas en otro lugar, puedes imprimir o copiar las notas en un documento."
+          "default": "This is an overview of your notes. They are saved locally in this browser. You can either print or copy the notes into a document."
         },
         {
           "label": "Etiqueta del botón de impresión de notas de la barra de navegación",

--- a/language/eu.json
+++ b/language/eu.json
@@ -409,7 +409,7 @@
         },
         {
           "label": "Navbar notes section body",
-          "default": "Here you have an overview of all the notes you have written. The notes are saved locally in this browser. To save the notes elsewhere, you can print or copy the notes into a document."
+          "default": "This is an overview of your notes. They are saved locally in this browser. You can either print or copy the notes into a document."
         },
         {
           "label": "Navbar notes print button label",

--- a/language/gl.json
+++ b/language/gl.json
@@ -409,7 +409,7 @@
         },
         {
           "label": "Corpo da sección de notas da barra de navegación",
-          "default": "Aquí tes unha visión xeral de todas as notas que escribiches. As notas gárdanse localmente neste navegador. Para gardar as notas noutro lugar, podes imprimir ou copiar as notas nun documento."
+          "default": "This is an overview of your notes. They are saved locally in this browser. You can either print or copy the notes into a document."
         },
         {
           "label": "Etiqueta do botón de impresión de notas da barra de navegación",

--- a/language/lt.json
+++ b/language/lt.json
@@ -409,7 +409,7 @@
         },
         {
           "label": "Navbar notes section body",
-          "default": "Here you have an overview of all the notes you have written. The notes are saved locally in this browser. To save the notes elsewhere, you can print or copy the notes into a document."
+          "default": "This is an overview of your notes. They are saved locally in this browser. You can either print or copy the notes into a document."
         },
         {
           "label": "Navbar notes print button label",

--- a/language/nb.json
+++ b/language/nb.json
@@ -409,7 +409,7 @@
         },
         {
           "label": "Beskrivese på notatside",
-          "default": "Here you have an overview of all the notes you have written. The notes are saved locally in this browser. To save the notes elsewhere, you can print or copy the notes into a document."
+          "default": "Dette er en oversikt over notatene dine. De er lagret lokalt i denne nettleseren. Du kan skrive ut eller kopiere notatene dine inn i et dokument."
         },
         {
           "label": "Skriv ut",

--- a/language/nn.json
+++ b/language/nn.json
@@ -409,7 +409,7 @@
         },
         {
           "label": "Beskrivese på notatside",
-          "default": "Here you have an overview of all the notes you have written. The notes are saved locally in this browser. To save the notes elsewhere, you can print or copy the notes into a document."
+          "default": "Dette er ei oversikt over notata dine. Dei er lagra lokalt i denne nettlesaren. Du kan skriva ut eller kopiera notata dine inn i eit dokument."
         },
         {
           "label": "Skriv ut",

--- a/semantics.json
+++ b/semantics.json
@@ -733,7 +733,7 @@
       {
         "label": "Navbar notes section body",
         "name": "navbarNotesSectionBody",
-        "default": "Here you have an overview of all the notes you have written. The notes are saved locally in this browser. To save the notes elsewhere, you can print or copy the notes into a document.",
+        "default": "This is an overview of your notes. They are saved locally in this browser. You can either print or copy the notes into a document.",
         "type": "text"
       },
       {

--- a/src/abstracts/_mixins.scss
+++ b/src/abstracts/_mixins.scss
@@ -8,3 +8,27 @@
   padding: 0;
   border: 0;
 }
+
+@mixin modal-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0,0,0,.7);
+  z-index: var(--overlay-z-index);
+}
+
+@mixin modal-content {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: #fff;
+  border-radius: 0.375rem;
+  height: 85vh;
+  width: 90vw;
+  padding: 1.5625rem;
+  overflow-y: auto;
+  z-index: var(--dialog-z-index);
+}

--- a/src/abstracts/_mixins.scss
+++ b/src/abstracts/_mixins.scss
@@ -28,9 +28,15 @@
   border-radius: 0.375rem;
   height: 80vh;
   width: 90vw;
-  padding: 1.5625rem;
-  overflow-y: auto;
+  padding: 0;
   z-index: var(--dialog-z-index);
+}
+
+@mixin modal-wrapper {
+  height: 100%;
+  overflow-y: auto;
+  padding: 2rem;
+  width: 100%;
 }
 
 @mixin modal-close-button {

--- a/src/abstracts/_mixins.scss
+++ b/src/abstracts/_mixins.scss
@@ -26,9 +26,34 @@
   transform: translate(-50%, -50%);
   background-color: #fff;
   border-radius: 0.375rem;
-  height: 85vh;
+  height: 80vh;
   width: 90vw;
   padding: 1.5625rem;
   overflow-y: auto;
   z-index: var(--dialog-z-index);
+}
+
+@mixin modal-close-button {
+  background-color: #ebebeb;
+  border: 8px solid #fff;
+  border-radius: 50%;
+  box-shadow: 0 0 1em 0 rgba(0,0,0,.2);
+  box-sizing: content-box;
+  color: black;
+  cursor: pointer;
+  padding: 4px;
+  position: fixed;
+  right: -1rem;
+  top: -1rem;
+
+  &:hover {
+    background-color: #d6d6d6;
+  }
+
+  svg {
+    display: block;
+    margin: auto;
+    height: 1.5rem;
+    width: 1.5rem;
+  }
 }

--- a/src/abstracts/_mixins.scss
+++ b/src/abstracts/_mixins.scss
@@ -11,10 +11,7 @@
 
 @mixin modal-overlay {
   position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+  inset: 0;
   background-color: rgba(0,0,0,.7);
   z-index: var(--overlay-z-index);
 }

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -83,7 +83,6 @@ export const App: React.FC<AppProps> = ({
                 params={params}
                 toggleIPhoneFullscreen={handleToggleIPhoneFullscreen}
                 isIPhoneFullscreenActive={isIPhoneFullscreenActive}
-                instance={instance}
               />
             </div>
           </FullScreen>

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { FullScreen, useFullScreenHandle } from 'react-full-screen';
 import type { IH5PContentType } from 'h5p-types';
 import { AppWidthContext } from '../../contexts/AppWidthContext';
+import { useH5PInstance } from '../../hooks/useH5PInstance';
 import { Params } from '../../types/Params';
 import { defaultTheme } from '../../utils/semantics.utils';
 import { Navbar } from '../Navbar/Navbar';
@@ -44,6 +45,10 @@ export const App: React.FC<AppProps> = ({
     [params.topicMap?.colorTheme],
   );
 
+  // Make sure theme is applied to the root element
+  const h5pInstance = useH5PInstance();
+  h5pInstance?.containerElement?.classList.add(themeClassName);
+
   /*
    * React supplies useResizeObserver hook, but H5P may trigger `resize` not
    * only when the window resizes
@@ -66,8 +71,7 @@ export const App: React.FC<AppProps> = ({
     >
       <AppWidthContext.Provider value={width}>
         <div
-          className={`${themeClassName} ${isIPhoneFullscreenActive && styles.iPhoneFullscreenThemeStyle
-          }`}
+          className={isIPhoneFullscreenActive ? styles.iPhoneFullscreenThemeStyle : ''}
         >
           <FullScreen
             className={styles.fullscreenStyle}

--- a/src/components/Arrow/Arrow.tsx
+++ b/src/components/Arrow/Arrow.tsx
@@ -14,6 +14,7 @@ import { useTranslation } from '../../hooks/useTranslation';
 import { H5P } from '../../h5p/H5P.util';
 import { Portal, Root, Trigger } from '@radix-ui/react-dialog';
 import { DialogWindow } from '../Dialog-Window/DialogWindow';
+import { useH5PInstance } from '../../hooks/useH5PInstance';
 
 export type ArrowProps = {
   item: ArrowItemType;
@@ -37,6 +38,7 @@ export const Arrow: FC<ArrowProps> = ({
   descriptiveText,
 }) => {
   const { t } = useTranslation();
+  const h5pInstance = useH5PInstance();
   const contentId = useContentId();
   const [userData] = useLocalStorageUserData();
 
@@ -223,7 +225,7 @@ export const Arrow: FC<ArrowProps> = ({
           buttonState={buttonState}
           strokeWidth={strokeWidth}
         />
-        <Portal>
+        <Portal container={h5pInstance?.containerElement}>
           <DialogWindow item={item} />
         </Portal>
       </Root>

--- a/src/components/ConfirmWindow/ConfirmWindow.module.scss
+++ b/src/components/ConfirmWindow/ConfirmWindow.module.scss
@@ -24,8 +24,9 @@
 .confirmWindowContent {
   @include modal-content;
   height: auto;
-  max-height: 85vh;
   width: 52vw;
+  max-height: 85vh;
+  max-width: 35rem;
   z-index: var(--confirm-dialog-z-index);
 
   @media (prefers-reduced-motion: no-preference) {

--- a/src/components/ConfirmWindow/ConfirmWindow.module.scss
+++ b/src/components/ConfirmWindow/ConfirmWindow.module.scss
@@ -1,3 +1,5 @@
+@use "./../../abstracts/mixins" as *;
+
 .overlay {
   opacity: 0.5;
   background-color: black;
@@ -38,26 +40,10 @@
 }
 
 .confirmWindowContent {
-  background-color: white;
-  border-radius: 0.375rem;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
-    Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
-  box-shadow: hsl(206 22% 7% / 35%) 0 10px 38px -10px,
-    hsl(206 22% 7% / 20%) 0 10px 20px -15px;
-  left: 50%;
+  @include modal-content;
+  height: auto;
   max-height: 85vh;
-  overflow: auto;
-  padding: 25px;
-  position: fixed;
-  top: 50%;
-  transform: translate(-50%, -50%);
   width: 40vw;
-  z-index: var(--dialog-z-index);
-
-  &,
-  * {
-    box-sizing: border-box;
-  }
 
   @media (prefers-reduced-motion: no-preference) {
     animation: show-dialog 150ms cubic-bezier(0.16, 1, 0.3, 1);
@@ -68,20 +54,32 @@
 .denyButton {
   background-color: #fff;
   border-radius: 0.25em;
-  border: 2px solid currentColor;
+  border: 2px solid var(--theme-color-2);
   box-sizing: border-box;
   color: var(--theme-color-2);
   cursor: pointer;
   display: inline-block;
   font-weight: 600;
   margin: 10px 0 0 0;
+  outline-offset: 2px;
   padding: 0.5rem 1.25rem;
   width: auto;
+
+  &:hover {
+    border-color: var(--theme-color-3);
+    color: var(--theme-color-3);
+  }
 }
 
 .confirmButton {
   background-color: var(--theme-color-2);
   color: #fff;
+
+  &:hover {
+    background-color: var(--theme-color-3);
+    border-color: var(--theme-color-3);
+    color: #fff;
+  }
 }
 
 .confirmationButtons {

--- a/src/components/ConfirmWindow/ConfirmWindow.module.scss
+++ b/src/components/ConfirmWindow/ConfirmWindow.module.scss
@@ -1,34 +1,16 @@
 @use "./../../abstracts/mixins" as *;
 
 .overlay {
-  opacity: 0.5;
-  background-color: black;
-  position: fixed;
-  inset: 0;
-  z-index: var(--overlay-z-index);
+  @include modal-overlay;
+  z-index: var(--confirm-overlay-z-index);
+}
+
+.contentWrapper {
+  @include modal-wrapper;
 }
 
 .closeButton {
-  background: none;
-  border: none;
-  border-radius: 2rem;
-  color: black;
-  cursor: pointer;
-  padding: 0.25rem;
-  position: fixed;
-  right: 0.625rem;
-  top: 0.625rem;
-
-  &:hover {
-    background-color: #eee;
-  }
-
-  svg {
-    display: block;
-    margin: auto;
-    height: 1.2rem;
-    width: 1.2rem;
-  }
+  @include modal-close-button;
 }
 
 .dialogTitle {
@@ -43,7 +25,8 @@
   @include modal-content;
   height: auto;
   max-height: 85vh;
-  width: 40vw;
+  width: 52vw;
+  z-index: var(--confirm-dialog-z-index);
 
   @media (prefers-reduced-motion: no-preference) {
     animation: show-dialog 150ms cubic-bezier(0.16, 1, 0.3, 1);

--- a/src/components/ConfirmWindow/ConfirmWindow.tsx
+++ b/src/components/ConfirmWindow/ConfirmWindow.tsx
@@ -1,9 +1,10 @@
-import { Close, Content, Overlay, Root, Title, Trigger } from '@radix-ui/react-dialog';
+import { Close, Content, Overlay, Portal, Root, Title, Trigger } from '@radix-ui/react-dialog';
 import { Cross2Icon } from '@radix-ui/react-icons';
 import * as React from 'react';
 import { FC, ReactNode } from 'react';
 import { useTranslation } from '../../hooks/useTranslation';
 import styles from './ConfirmWindow.module.scss';
+import { useH5PInstance } from '../../hooks/useH5PInstance';
 
 export type ConfirmWindowProps = {
   title: string;
@@ -25,6 +26,7 @@ export const ConfirmWindow: FC<ConfirmWindowProps> = ({
   children,
 }) => {
   const { t } = useTranslation();
+  const h5pInstance = useH5PInstance();
   const ariaLabel = t('closeDialog');
 
   const [windowOpen, setWindowOpen] = React.useState(false);
@@ -36,35 +38,39 @@ export const ConfirmWindow: FC<ConfirmWindowProps> = ({
 
   return (
     <Root open={windowOpen} onOpenChange={setWindowOpen}>
-      <Overlay className={styles.overlay} />
       <Trigger asChild>
         <button type="button" className={button.className} onClick={() => setWindowOpen(true)}>
           {button.label}
         </button>
       </Trigger>
-      <Content className={styles.confirmWindowContent}>
-        <Title className={styles.dialogTitle}>{title}</Title>
-        {children}
-        <div className={styles.confirmationButtons}>
-          <button
-            type="button"
-            className={styles.confirmButton}
-            onClick={handleConfirm}
-          >
-            {confirmWindow.confirmText}
-          </button>
-          <button
-            type="button"
-            className={styles.denyButton}
-            onClick={() => setWindowOpen(false)}
-          >
-            {confirmWindow.denyText}
-          </button>
-        </div>
-        <Close className={styles.closeButton} aria-label={ariaLabel}>
-          <Cross2Icon />
-        </Close>
-      </Content>
+      <Portal container={h5pInstance?.containerElement}>
+        <Overlay className={styles.overlay} />
+        <Content className={styles.confirmWindowContent}>
+          <div className={styles.contentWrapper}>
+            <Title className={styles.dialogTitle}>{title}</Title>
+            {children}
+            <div className={styles.confirmationButtons}>
+              <button
+                type="button"
+                className={styles.confirmButton}
+                onClick={handleConfirm}
+              >
+                {confirmWindow.confirmText}
+              </button>
+              <button
+                type="button"
+                className={styles.denyButton}
+                onClick={() => setWindowOpen(false)}
+              >
+                {confirmWindow.denyText}
+              </button>
+            </div>
+          </div>
+          <Close className={styles.closeButton} aria-label={ariaLabel}>
+            <Cross2Icon />
+          </Close>
+        </Content>
+      </Portal>
     </Root>
   );
 };

--- a/src/components/Dialog-Window/DialogWindow.module.scss
+++ b/src/components/Dialog-Window/DialogWindow.module.scss
@@ -5,33 +5,21 @@
 }
 
 .closeButton {
-  background: none;
-  border: none;
-  border-radius: 2rem;
-  color: black;
-  cursor: pointer;
-  padding: 0.25rem;
-  position: fixed;
-  right: 0.625rem;
-  top: 0.625rem;
+  @include modal-close-button;
+}
 
-  &:hover {
-    background-color: #eee;
-  }
-
-  svg {
-    display: block;
-    margin: auto;
-    height: 1.2rem;
-    width: 1.2rem;
-  }
+.contentWrapper {
+  flex: 1;
+  height: 100%;
+  width: 100%;
+  overflow-y: auto;
 }
 
 .dialogContent,
 .dialogContentWide,
 .dialogContentSmallScreen {
   @include modal-content;
-  overflow-y: hidden;
+  overflow-y: unset;
 }
 
 .dialogContent {
@@ -43,7 +31,7 @@
 }
 
 .dialogContentSmallScreen {
-  width: 95vw;
+  width: 90vw;
 }
 
 .tabWrapper {

--- a/src/components/Dialog-Window/DialogWindow.module.scss
+++ b/src/components/Dialog-Window/DialogWindow.module.scss
@@ -1,9 +1,7 @@
+@use "./../../abstracts/mixins" as *;
+
 .overlay {
-  opacity: 0.5;
-  background-color: black;
-  position: fixed;
-  inset: 0;
-  z-index: var(--overlay-z-index);
+  @include modal-overlay;
 }
 
 .closeButton {
@@ -32,24 +30,8 @@
 .dialogContent,
 .dialogContentWide,
 .dialogContentSmallScreen {
-  background-color: white;
-  border-radius: 6px;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
-    Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  height: 85vh;
-  z-index: var(--dialog-z-index);
-  padding: 1.5625rem;
-  overflow: auto;
+  @include modal-content;
   overflow-y: hidden;
-
-  &,
-  * {
-    box-sizing: border-box;
-  }
 }
 
 .dialogContent {

--- a/src/components/Dialog-Window/DialogWindow.module.scss
+++ b/src/components/Dialog-Window/DialogWindow.module.scss
@@ -9,17 +9,19 @@
 }
 
 .contentWrapper {
-  flex: 1;
-  height: 100%;
-  width: 100%;
-  overflow-y: auto;
+  @include modal-wrapper;
+}
+
+.contentWrapperSmallScreen {
+  @include modal-wrapper;
+  display: flex;
+  flex-direction: column;
 }
 
 .dialogContent,
 .dialogContentWide,
 .dialogContentSmallScreen {
   @include modal-content;
-  overflow-y: unset;
 }
 
 .dialogContent {
@@ -43,7 +45,7 @@
 .noteWrapper {
   float: right;
   width: 47%;
-  height: 80%;
+  height: 90%;
 
   &.fullWidth {
     float: left;

--- a/src/components/Dialog-Window/DialogWindow.tsx
+++ b/src/components/Dialog-Window/DialogWindow.tsx
@@ -39,7 +39,7 @@ export const DialogWindow: FC<DialogWindowProps> = ({
 
   let content = smallScreen ? (
     <Content className={styles.dialogContentSmallScreen}>
-      <div className={styles.contentWrapper}>
+      <div className={styles.contentWrapperSmallScreen}>
         <Title className={styles.dialogTitle}>{item.label}</Title>
         {!noTabItems && <DialogTabs item={item} />}
         {noTabItems && hasNote && (

--- a/src/components/Dialog-Window/DialogWindow.tsx
+++ b/src/components/Dialog-Window/DialogWindow.tsx
@@ -39,27 +39,31 @@ export const DialogWindow: FC<DialogWindowProps> = ({
 
   let content = smallScreen ? (
     <Content className={styles.dialogContentSmallScreen}>
-      <Title className={styles.dialogTitle}>{item.label}</Title>
-      {!noTabItems && <DialogTabs item={item} />}
-      {noTabItems && hasNote && (
-        <div className={`${styles.noteWrapper} ${styles.fullWidth}`}>
-          <DialogNote
-            maxLength={item.dialog.maxLength}
-            id={item.id}
-          />
-        </div>
-      )}
+      <div className={styles.contentWrapper}>
+        <Title className={styles.dialogTitle}>{item.label}</Title>
+        {!noTabItems && <DialogTabs item={item} />}
+        {noTabItems && hasNote && (
+          <div className={`${styles.noteWrapper} ${styles.fullWidth}`}>
+            <DialogNote
+              maxLength={item.dialog.maxLength}
+              id={item.id}
+            />
+          </div>
+        )}
+      </div>
       <Close className={styles.closeButton} aria-label={ariaLabel}>
         <Cross2Icon />
       </Close>
     </Content>
   ) : (
     <Content className={styles.dialogContent}>
-      <Title
-        className={styles.dialogTitle}
-        dangerouslySetInnerHTML={{ __html: item.label }}
-      />
-      {!noTabItems && <DialogTabs item={item} />}
+      <div className={styles.contentWrapper}>
+        <Title
+          className={styles.dialogTitle}
+          dangerouslySetInnerHTML={{ __html: item.label }}
+        />
+        {!noTabItems && <DialogTabs item={item} />}
+      </div>
       <Close className={styles.closeButton} aria-label={ariaLabel}>
         <Cross2Icon />
       </Close>
@@ -71,23 +75,25 @@ export const DialogWindow: FC<DialogWindowProps> = ({
       <Content
         className={noTabItems ? styles.dialogContent : styles.dialogContentWide}
       >
-        <Title
-          className={styles.dialogTitle}
-          dangerouslySetInnerHTML={{ __html: item.label }}
-        />
-        {!noTabItems && (
-          <div className={styles.tabWrapper}>
-            <DialogTabs item={item} />
-          </div>
-        )}
-        <div
-          className={`${styles.noteWrapper} ${noTabItems ? styles.fullWidth : ''
-          }`}
-        >
-          <DialogNote
-            maxLength={item.dialog.maxLength}
-            id={item.id}
+        <div className={styles.contentWrapper}>
+          <Title
+            className={styles.dialogTitle}
+            dangerouslySetInnerHTML={{ __html: item.label }}
           />
+          {!noTabItems && (
+            <div className={styles.tabWrapper}>
+              <DialogTabs item={item} />
+            </div>
+          )}
+          <div
+            className={`${styles.noteWrapper} ${noTabItems ? styles.fullWidth : ''
+            }`}
+          >
+            <DialogNote
+              maxLength={item.dialog.maxLength}
+              id={item.id}
+            />
+          </div>
         </div>
         <Close className={styles.closeButton} aria-label={ariaLabel}>
           <Cross2Icon />

--- a/src/components/Dialog-Window/Notes/DialogNote.module.scss
+++ b/src/components/Dialog-Window/Notes/DialogNote.module.scss
@@ -1,6 +1,9 @@
 @use "./../../../abstracts/mixins" as *;
 
 form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
   position: relative;
   width: 100%;
   height: 100%;
@@ -29,9 +32,9 @@ form {
   border-radius: 0.25rem;
   display: flex;
   flex-direction: column;
-  height: 100%;
+  height: 90%;
+  min-height: 12rem;
   position: relative;
-  top: 0.5rem;
 
   &:focus-within {
     border: 2px solid #2360c5;

--- a/src/components/Dialog-Window/Tabs/DialogTabs.module.scss
+++ b/src/components/Dialog-Window/Tabs/DialogTabs.module.scss
@@ -43,13 +43,10 @@
 .tabs {
   display: flex;
   flex-direction: column;
-  width: 300;
-  height: 100%;
+  flex-grow: 2;
 }
 
 .tabItemWrapper {
-  overflow-y: scroll;
-  overflow: auto;
   height: 100%;
 
   &.marginTop {
@@ -58,5 +55,5 @@
 }
 
 .noteWrapper {
-  height: 80%;
+  height: 100%;
 }

--- a/src/components/Navbar/Navbar.module.scss
+++ b/src/components/Navbar/Navbar.module.scss
@@ -23,16 +23,6 @@
   position: relative;
 }
 
-.sectionContentWrapper {
-  background-color: #ffffff;
-  overflow-y: auto;
-  position: absolute;
-  right: 0;
-  top: 0;
-  width: 100%;
-  z-index: var(--notesection-z-index);
-}
-
 .sectionTitle {
   background-color: transparent;
   border: none;
@@ -154,4 +144,13 @@
   .visuallyHidden {
     @include visually-hidden;
   }
+}
+
+.overlay {
+  @include modal-overlay;
+}
+
+.dialogContent {
+  @include modal-content;
+  padding: 0;
 }

--- a/src/components/Navbar/Navbar.module.scss
+++ b/src/components/Navbar/Navbar.module.scss
@@ -23,24 +23,6 @@
   position: relative;
 }
 
-.sectionTitle {
-  background-color: transparent;
-  border: none;
-  border-radius: 2rem;
-  cursor: pointer;
-  color: #ffffff;
-  padding: 0.5rem 1rem;
-  white-space: nowrap;
-
-  &:hover {
-    background-color: var(--theme-color-3);
-  }
-
-  &.active {
-    text-decoration: underline;
-  }
-}
-
 .sectionsMenu {
   display: flex;
   flex-direction: row;
@@ -48,12 +30,6 @@
 
 .progressBarWrapper {
   display: none;
-}
-
-.notesList {
-  @media print {
-    max-height: unset !important;
-  }
 }
 
 .fullscreenButton {
@@ -144,25 +120,4 @@
   .visuallyHidden {
     @include visually-hidden;
   }
-}
-
-.overlay {
-  @include modal-overlay;
-}
-
-.dialogContent {
-  @include modal-content;
-  padding: 0;
-  overflow: unset;
-}
-
-.closeButton {
-  @include modal-close-button;
-}
-
-.contentWrapper {
-  flex: 1;
-  height: 100%;
-  width: 100%;
-  overflow-y: auto;
 }

--- a/src/components/Navbar/Navbar.module.scss
+++ b/src/components/Navbar/Navbar.module.scss
@@ -153,4 +153,16 @@
 .dialogContent {
   @include modal-content;
   padding: 0;
+  overflow: unset;
+}
+
+.closeButton {
+  @include modal-close-button;
+}
+
+.contentWrapper {
+  flex: 1;
+  height: 100%;
+  width: 100%;
+  overflow-y: auto;
 }

--- a/src/components/Navbar/Navbar.stories.tsx
+++ b/src/components/Navbar/Navbar.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta, StoryFn } from '@storybook/react';
-import type { IH5PContentType } from 'h5p-types';
 import * as React from 'react';
 import { Navbar, NavbarProps } from './Navbar';
 
@@ -13,11 +12,6 @@ const defaultArgs: NavbarProps = {
   params: {},
   toggleIPhoneFullscreen: () => null,
   isIPhoneFullscreenActive: false,
-  instance: {
-    on: () => {
-      /* Empty */
-    },
-  } as unknown as IH5PContentType,
 };
 
 export const NavBar: StoryFn<typeof Navbar> = () => {
@@ -264,6 +258,6 @@ export const NavBar: StoryFn<typeof Navbar> = () => {
       },
     },
   };
-  
+
   return <Navbar {...args} />;
 };

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -13,8 +13,9 @@ import { FullscreenButton } from '../FullscreenButton/FullscreenButton';
 import { Grid } from '../Grid/Grid';
 import { NotesList } from './NotesSection/NotesList/NotesList';
 import { NotesSection } from './NotesSection/NotesSection';
-import { Content, Overlay, Portal, Root, Trigger } from '@radix-ui/react-dialog';
+import { Close, Content, Overlay, Portal, Root, Trigger } from '@radix-ui/react-dialog';
 import styles from './Navbar.module.scss';
+import { Cross2Icon } from '@radix-ui/react-icons';
 
 export type NavbarProps = {
   navbarTitle: string;
@@ -117,18 +118,29 @@ export const Navbar: React.FC<NavbarProps> = ({
       <Portal container={h5pInstance?.containerElement}>
         <Overlay className={styles.overlay} />
         <Content className={styles.dialogContent}>
-          <NotesSection
-            handlePrint={handlePrint}
-            confirmSubmitAll={submitAllNotes}
-            confirmDeletion={deleteAllNotes}
-          />
-          <div
-            className={styles.notesList}
-            ref={notesListRef}
-            title={navbarTitleForPrint}
-          >
-            <NotesList topicMapItems={allItems} navbarTitle={navbarTitle} />
+          <div className={styles.contentWrapper}>
+            <NotesSection
+              handlePrint={handlePrint}
+              confirmSubmitAll={submitAllNotes}
+              confirmDeletion={deleteAllNotes}
+            />
+            <div
+              className={styles.notesList}
+              ref={notesListRef}
+              title={navbarTitleForPrint}
+            >
+              <NotesList topicMapItems={allItems} navbarTitle={navbarTitle} />
+            </div>
           </div>
+          <Close asChild>
+            <button
+              type="button"
+              className={styles.closeButton}
+              aria-label={t('closeDialog')}
+            >
+              <Cross2Icon />
+            </button>
+          </Close>
         </Content>
       </Portal>
     </Root>

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { useState } from 'react';
-import { useReactToPrint } from 'react-to-print';
 import { useContentId } from '../../hooks/useContentId';
 import { useH5PInstance } from '../../hooks/useH5PInstance';
 import { useLocalStorageUserData } from '../../hooks/useLocalStorageUserData';
@@ -11,11 +10,8 @@ import { Params } from '../../types/Params';
 import { exportAllUserData } from '../../utils/user-data.utils';
 import { FullscreenButton } from '../FullscreenButton/FullscreenButton';
 import { Grid } from '../Grid/Grid';
-import { NotesList } from './NotesSection/NotesList/NotesList';
 import { NotesSection } from './NotesSection/NotesSection';
-import { Close, Content, Overlay, Portal, Root, Trigger } from '@radix-ui/react-dialog';
 import styles from './Navbar.module.scss';
-import { Cross2Icon } from '@radix-ui/react-icons';
 
 export type NavbarProps = {
   navbarTitle: string;
@@ -73,18 +69,6 @@ export const Navbar: React.FC<NavbarProps> = ({
     );
   }, [allItems, contentId, totalNotesToComplete, userData]);
 
-  let navbarTitleForPrint = '';
-  const updateNavbarTitleForPrint = (): void => {
-    navbarTitleForPrint = navbarTitleForPrint ? '' : navbarTitle;
-  };
-  const notesListRef = React.useRef(null);
-  const handlePrint = useReactToPrint({
-    content: () => notesListRef.current,
-    documentTitle: navbarTitle,
-    onBeforeGetContent: updateNavbarTitleForPrint,
-    onAfterPrint: updateNavbarTitleForPrint,
-  });
-
   const deleteAllNotes = (): void => {
     allItems.forEach((item) => {
       if (userData[contentId]?.dialogs?.[item.id]) {
@@ -102,49 +86,6 @@ export const Navbar: React.FC<NavbarProps> = ({
 
     exportAllUserData(contentId, h5pInstance);
   };
-
-  const notesSection = (
-    <Root open={notesOpen} onOpenChange={setNotesOpen}>
-      <Trigger asChild>
-        <button
-          className={`${styles.sectionTitle} ${notesOpen && styles.active
-          }`}
-          type="button"
-          onClick={() => setNotesOpen(true)}
-        >
-          {t('navbarNotesSectionLabel')}
-        </button>
-      </Trigger>
-      <Portal container={h5pInstance?.containerElement}>
-        <Overlay className={styles.overlay} />
-        <Content className={styles.dialogContent}>
-          <div className={styles.contentWrapper}>
-            <NotesSection
-              handlePrint={handlePrint}
-              confirmSubmitAll={submitAllNotes}
-              confirmDeletion={deleteAllNotes}
-            />
-            <div
-              className={styles.notesList}
-              ref={notesListRef}
-              title={navbarTitleForPrint}
-            >
-              <NotesList topicMapItems={allItems} navbarTitle={navbarTitle} />
-            </div>
-          </div>
-          <Close asChild>
-            <button
-              type="button"
-              className={styles.closeButton}
-              aria-label={t('closeDialog')}
-            >
-              <Cross2Icon />
-            </button>
-          </Close>
-        </Content>
-      </Portal>
-    </Root>
-  );
 
   const progressBar = (
     <div className={styles.progressBarWrapper}>
@@ -187,7 +128,14 @@ export const Navbar: React.FC<NavbarProps> = ({
             </div>
             {hasNotes && (
               <div className={styles.sectionsMenu}>
-                {notesSection}
+                <NotesSection
+                  confirmSubmitAll={submitAllNotes}
+                  confirmDeletion={deleteAllNotes}
+                  notesOpen={notesOpen}
+                  setNotesOpen={setNotesOpen}
+                  navbarTitle={navbarTitle}
+                  allItems={allItems}
+                />
                 {progressBar}
               </div>
             )}

--- a/src/components/Navbar/NotesSection/NotesList/NotesList.module.scss
+++ b/src/components/Navbar/NotesSection/NotesList/NotesList.module.scss
@@ -2,7 +2,7 @@
   display: flex;
   height: 100%;
   width: 100%;
-  padding: 1rem 2rem;
+  padding: 1rem 0;
 }
 
 .mainBodyContent {

--- a/src/components/Navbar/NotesSection/NotesList/NotesList.module.scss
+++ b/src/components/Navbar/NotesSection/NotesList/NotesList.module.scss
@@ -1,9 +1,8 @@
 .mainBody {
   display: flex;
-  align-items: center;
-  justify-content: center;
   height: 100%;
   width: 100%;
+  padding: 1rem 2rem;
 }
 
 .mainBodyContent {

--- a/src/components/Navbar/NotesSection/NotesList/NotesList.module.scss
+++ b/src/components/Navbar/NotesSection/NotesList/NotesList.module.scss
@@ -61,7 +61,7 @@
 
   .mainBodyHeaderForPrint {
     overflow: visible;
-    height: 100%;
+    height: auto;
   }
 }
 

--- a/src/components/Navbar/NotesSection/NotesSection.module.scss
+++ b/src/components/Navbar/NotesSection/NotesSection.module.scss
@@ -1,10 +1,8 @@
 @use "./../../../abstracts/mixins" as *;
 
 .mainBody {
-  background-color: #fff;
   border-bottom: 2px solid #eee;
   line-height: 1.5;
-  overflow-y: auto;
   padding-bottom: 1.5625rem;
 
   p {
@@ -42,6 +40,7 @@
   cursor: pointer;
   color: #ffffff;
   padding: 0.5rem 1rem;
+  outline-offset: 2px;
 
   &:hover {
     background-color: var(--theme-color-3);

--- a/src/components/Navbar/NotesSection/NotesSection.module.scss
+++ b/src/components/Navbar/NotesSection/NotesSection.module.scss
@@ -1,20 +1,17 @@
+@use "./../../../abstracts/mixins" as *;
+
 .mainBody {
-  display: flex;
   background-color: #fff;
-  padding: 1.5625rem 0;
   border-bottom: 2px solid #eee;
+  line-height: 1.5;
   margin: 0 2rem;
+  overflow-y: auto;
+  padding: 1.5625rem 0;
 
   p {
     margin-block-start: 0;
     margin-block-end: 0;
   }
-}
-
-.mainBodyContent {
-  height: 100%;
-  line-height: 1.5;
-  overflow-y: auto;
 }
 
 .mainBodyTitle {
@@ -24,25 +21,13 @@
 }
 
 .mainBodyTextWrapper {
-  display: flex;
-  flex-direction: column;
-  margin-top: 1.5rem;
-
-  .smallUp & {
-    flex-direction: row;
-    gap: 5%;
-  }
-}
-
-.mainBodyText {
-  //max-width: 40em;
-  //width: 80%;
+  margin-top: 1rem;
 }
 
 .mainBodyButtons {
   display: flex;
   flex-direction: column;
-  gap: 1rem 1.5rem;
+  gap: 1rem;
   margin-top: 1.5rem;
   width: 100%;
 
@@ -62,4 +47,49 @@
   &:hover {
     background-color: var(--theme-color-3);
   }
+}
+
+.sectionTitle {
+  background-color: transparent;
+  border: none;
+  border-radius: 2rem;
+  cursor: pointer;
+  color: #ffffff;
+  padding: 0.5rem 1rem;
+  white-space: nowrap;
+
+  &:hover {
+    background-color: var(--theme-color-3);
+  }
+
+  &.active {
+    text-decoration: underline;
+  }
+}
+
+.notesList {
+  @media print {
+    max-height: unset !important;
+  }
+}
+
+.overlay {
+  @include modal-overlay;
+}
+
+.dialogContent {
+  @include modal-content;
+  padding: 0;
+  overflow: unset;
+}
+
+.closeButton {
+  @include modal-close-button;
+}
+
+.contentWrapper {
+  flex: 1;
+  height: 100%;
+  width: 100%;
+  overflow-y: auto;
 }

--- a/src/components/Navbar/NotesSection/NotesSection.module.scss
+++ b/src/components/Navbar/NotesSection/NotesSection.module.scss
@@ -4,9 +4,8 @@
   background-color: #fff;
   border-bottom: 2px solid #eee;
   line-height: 1.5;
-  margin: 0 2rem;
   overflow-y: auto;
-  padding: 1.5625rem 0;
+  padding-bottom: 1.5625rem;
 
   p {
     margin-block-start: 0;
@@ -79,8 +78,6 @@
 
 .dialogContent {
   @include modal-content;
-  padding: 0;
-  overflow: unset;
 }
 
 .closeButton {
@@ -88,8 +85,5 @@
 }
 
 .contentWrapper {
-  flex: 1;
-  height: 100%;
-  width: 100%;
-  overflow-y: auto;
+  @include modal-wrapper;
 }

--- a/src/components/Navbar/NotesSection/NotesSection.module.scss
+++ b/src/components/Navbar/NotesSection/NotesSection.module.scss
@@ -77,6 +77,7 @@
 
 .dialogContent {
   @include modal-content;
+  max-width: 45rem;
 }
 
 .closeButton {

--- a/src/components/Navbar/NotesSection/NotesSection.module.scss
+++ b/src/components/Navbar/NotesSection/NotesSection.module.scss
@@ -3,9 +3,8 @@
   align-items: center;
   justify-content: center;
   background-color: var(--theme-color-2);
-  height: 100%;
   width: 100%;
-  padding: 1rem 0;
+  padding: 1.5625rem 0;
 
   p {
     color: #ffffff;
@@ -70,35 +69,25 @@
   }
 }
 
-.backArrow {
-  align-items: center;
+.closeButton {
   background-color: var(--theme-color-1);
   border: none;
-  border-radius: 50%;
+  border-radius: 2rem;
   color: inherit;
   cursor: pointer;
-  display: flex;
-  font-size: 1rem !important;
-  gap: 0.5rem;
-  height: 2rem;
-  margin-bottom: 1rem;
-  padding: 0.0625rem 0.375rem;
-  position: relative;
-  transform: none;
-  width: 2rem;
+  padding: 0.25rem;
+  position: fixed;
+  right: 0.625rem;
+  top: 0.625rem;
 
   &:hover {
     background-color: var(--theme-color-3);
   }
 
   svg {
-    height: 1.375rem;
-    width: 1.375rem;
-  }
-
-  .xSmallUp & {
-    position: absolute;
-    transform: translateX(-100%);
-    left: -1rem;
+    display: block;
+    margin: auto;
+    height: 1.2rem;
+    width: 1.2rem;
   }
 }

--- a/src/components/Navbar/NotesSection/NotesSection.module.scss
+++ b/src/components/Navbar/NotesSection/NotesSection.module.scss
@@ -1,23 +1,20 @@
 .mainBody {
   display: flex;
-  align-items: center;
-  justify-content: center;
-  background-color: var(--theme-color-2);
-  width: 100%;
+  background-color: #fff;
   padding: 1.5625rem 0;
+  border-bottom: 2px solid #eee;
+  margin: 0 2rem;
 
   p {
-    color: #ffffff;
     margin-block-start: 0;
     margin-block-end: 0;
   }
 }
 
 .mainBodyContent {
-  color: #ffffff;
   height: 100%;
   line-height: 1.5;
-  width: 75%;
+  overflow-y: auto;
 }
 
 .mainBodyTitle {
@@ -38,16 +35,14 @@
 }
 
 .mainBodyText {
-  max-width: 40em;
-  width: 80%;
+  //max-width: 40em;
+  //width: 80%;
 }
 
 .mainBodyButtons {
-  align-self: flex-end;
   display: flex;
   flex-direction: column;
   gap: 1rem 1.5rem;
-  justify-content: flex-end;
   margin-top: 1.5rem;
   width: 100%;
 
@@ -57,7 +52,7 @@
 }
 
 .mainBodyButton {
-  background-color: var(--theme-color-1);
+  background-color: var(--theme-color-2);
   border: none;
   border-radius: 1rem;
   cursor: pointer;
@@ -66,28 +61,5 @@
 
   &:hover {
     background-color: var(--theme-color-3);
-  }
-}
-
-.closeButton {
-  background-color: var(--theme-color-1);
-  border: none;
-  border-radius: 2rem;
-  color: inherit;
-  cursor: pointer;
-  padding: 0.25rem;
-  position: fixed;
-  right: 0.625rem;
-  top: 0.625rem;
-
-  &:hover {
-    background-color: var(--theme-color-3);
-  }
-
-  svg {
-    display: block;
-    margin: auto;
-    height: 1.2rem;
-    width: 1.2rem;
   }
 }

--- a/src/components/Navbar/NotesSection/NotesSection.stories.tsx
+++ b/src/components/Navbar/NotesSection/NotesSection.stories.tsx
@@ -13,7 +13,10 @@ const Template: StoryFn<typeof NotesSection> = (args) => (
 
 export const Notes = Template.bind({});
 Notes.args = {
-  handlePrint: () => { },
   confirmSubmitAll: () => { },
   confirmDeletion: () => { },
+  notesOpen: false,
+  setNotesOpen: () => { },
+  navbarTitle: 'Navbar Title',
+  allItems: [],
 };

--- a/src/components/Navbar/NotesSection/NotesSection.stories.tsx
+++ b/src/components/Navbar/NotesSection/NotesSection.stories.tsx
@@ -14,7 +14,6 @@ const Template: StoryFn<typeof NotesSection> = (args) => (
 export const Notes = Template.bind({});
 Notes.args = {
   handlePrint: () => { },
-  goToTopicMap: () => { },
   confirmSubmitAll: () => { },
   confirmDeletion: () => { },
 };

--- a/src/components/Navbar/NotesSection/NotesSection.tsx
+++ b/src/components/Navbar/NotesSection/NotesSection.tsx
@@ -1,21 +1,20 @@
-import { ArrowLeftIcon } from '@radix-ui/react-icons';
+import { Cross2Icon } from '@radix-ui/react-icons';
 import * as React from 'react';
 import { H5PIntegration } from '../../../h5p/H5P.util';
 import { useSizeClassNames } from '../../../hooks/useSizeClassNames';
 import { useTranslation } from '../../../hooks/useTranslation';
 import { ConfirmWindow } from '../../ConfirmWindow/ConfirmWindow';
+import { Close, Title } from '@radix-ui/react-dialog';
 import styles from './NotesSection.module.scss';
 
 export type NotesSectionProps = {
   handlePrint: () => void;
-  goToTopicMap: () => void;
   confirmSubmitAll: () => void;
   confirmDeletion: () => void;
 };
 
 export const NotesSection: React.FC<NotesSectionProps> = ({
   handlePrint,
-  goToTopicMap,
   confirmSubmitAll,
   confirmDeletion,
 }) => {
@@ -31,15 +30,18 @@ export const NotesSection: React.FC<NotesSectionProps> = ({
     <div className={`${styles.mainBody} ${sizeClassNames}`}>
       <div className={styles.mainBodyContent}>
         <div className={styles.mainBodyTitle}>
-          <button
-            type="button"
-            onClick={goToTopicMap}
-            className={styles.backArrow}
-            aria-label={t('goToTopicMapLabel')}
-          >
-            <ArrowLeftIcon width={22} height={22} />
-          </button>
-          <p>{t('navbarNotesSectionTitle')}</p>
+          <Close asChild>
+            <button
+              type="button"
+              className={styles.closeButton}
+              aria-label={t('closeDialog')}
+            >
+              <Cross2Icon />
+            </button>
+          </Close>
+          <Title asChild>
+            <p>{t('navbarNotesSectionTitle')}</p>
+          </Title>
         </div>
         <div className={styles.mainBodyTextWrapper}>
           <div className={styles.mainBodyText}>

--- a/src/components/Navbar/NotesSection/NotesSection.tsx
+++ b/src/components/Navbar/NotesSection/NotesSection.tsx
@@ -1,24 +1,35 @@
-import { Cross2Icon } from '@radix-ui/react-icons';
 import * as React from 'react';
+import { Cross2Icon } from '@radix-ui/react-icons';
 import { H5PIntegration } from '../../../h5p/H5P.util';
 import { useSizeClassNames } from '../../../hooks/useSizeClassNames';
 import { useTranslation } from '../../../hooks/useTranslation';
 import { ConfirmWindow } from '../../ConfirmWindow/ConfirmWindow';
-import { Close, Title } from '@radix-ui/react-dialog';
+import { Close, Content, Overlay, Portal, Root, Title, Trigger } from '@radix-ui/react-dialog';
+import { useH5PInstance } from '../../../hooks/useH5PInstance';
+import { NotesList } from './NotesList/NotesList';
+import { CommonItemType } from '../../../types/CommonItemType';
+import { useReactToPrint } from 'react-to-print';
 import styles from './NotesSection.module.scss';
 
 export type NotesSectionProps = {
-  handlePrint: () => void;
   confirmSubmitAll: () => void;
   confirmDeletion: () => void;
+  notesOpen: boolean;
+  setNotesOpen: (open: boolean) => void;
+  navbarTitle: string;
+  allItems: CommonItemType[];
 };
 
 export const NotesSection: React.FC<NotesSectionProps> = ({
-  handlePrint,
   confirmSubmitAll,
   confirmDeletion,
+  notesOpen,
+  setNotesOpen,
+  navbarTitle,
+  allItems,
 }) => {
   const { t } = useTranslation();
+  const h5pInstance = useH5PInstance();
 
   const printText = t('navbarNotesSectionPrintLabel');
   const exportAllUserDataText = t('navbarNotesSectionSubmitAllLabel');
@@ -26,56 +37,101 @@ export const NotesSection: React.FC<NotesSectionProps> = ({
 
   const sizeClassNames = useSizeClassNames(styles);
 
+  let navbarTitleForPrint = '';
+  const updateNavbarTitleForPrint = (): void => {
+    navbarTitleForPrint = navbarTitleForPrint ? '' : navbarTitle;
+  };
+  const notesListRef = React.useRef(null);
+  const handlePrint = useReactToPrint({
+    content: () => notesListRef.current,
+    documentTitle: navbarTitle,
+    onBeforeGetContent: updateNavbarTitleForPrint,
+    onAfterPrint: updateNavbarTitleForPrint,
+  });
+
+  const exportAllButtonAndWindow = (
+    <ConfirmWindow
+      title={t('submitDataConfirmationWindowLabel')}
+      confirmWindow={{
+        confirmAction: confirmSubmitAll,
+        confirmText: t('submitDataConfirmLabel'),
+        denyText: t('submitDataDenyLabel'),
+      }}
+      button={{
+        className: styles.mainBodyButton,
+        label: exportAllUserDataText,
+      }}
+    />
+  );
+
+  const deleteButtonAndWindow = (
+    <ConfirmWindow
+      title={t('deleteNotesConfirmationWindowLabel')}
+      confirmWindow={{
+        confirmAction: confirmDeletion,
+        confirmText: t('deleteNotesConfirmLabel'),
+        denyText: t('deleteNotesDenyLabel'),
+      }}
+      button={{
+        className: styles.mainBodyButton,
+        label: deleteText,
+      }}
+    />
+  );
+
   return (
-    <div className={`${styles.mainBody} ${sizeClassNames}`}>
-      <div className={styles.mainBodyContent}>
-        <div className={styles.mainBodyTitle}>
-          <Title asChild>
-            <p>{t('navbarNotesSectionTitle')}</p>
-          </Title>
-        </div>
-        <div className={styles.mainBodyTextWrapper}>
-          <div className={styles.mainBodyText}>
-            {t('navbarNotesSectionBody')}
-          </div>
-          <div className={styles.mainBodyButtons}>
-            <button
-              className={styles.mainBodyButton}
-              type="button"
-              aria-label={printText}
-              onClick={handlePrint}
+    <Root open={notesOpen} onOpenChange={setNotesOpen}>
+      <Trigger asChild>
+        <button
+          className={`${styles.sectionTitle} ${notesOpen && styles.active
+          }`}
+          type="button"
+          onClick={() => setNotesOpen(true)}
+        >
+          {t('navbarNotesSectionLabel')}
+        </button>
+      </Trigger>
+      <Portal container={h5pInstance?.containerElement}>
+        <Overlay className={styles.overlay} />
+        <Content className={styles.dialogContent}>
+          <div className={styles.contentWrapper}>
+            <div className={`${styles.mainBody} ${sizeClassNames}`}>
+              <Title asChild>
+                <p className={styles.mainBodyTitle}>
+                  {t('navbarNotesSectionTitle')}
+                </p>
+              </Title>
+              <div className={styles.mainBodyTextWrapper}>
+                {t('navbarNotesSectionBody')}
+              </div>
+              <div className={styles.mainBodyButtons}>
+                <button
+                  className={styles.mainBodyButton}
+                  type="button"
+                  aria-label={printText}
+                  onClick={handlePrint}
+                >
+                  {printText}
+                </button>
+                {H5PIntegration.reportingIsEnabled ? (
+                  exportAllButtonAndWindow
+                ) : null}
+                {deleteButtonAndWindow}
+              </div>
+            </div>
+            <div
+              className={styles.notesList}
+              ref={notesListRef}
+              title={navbarTitleForPrint}
             >
-              {printText}
-            </button>
-            {H5PIntegration.reportingIsEnabled ? (
-              <ConfirmWindow
-                title={t('submitDataConfirmationWindowLabel')}
-                confirmWindow={{
-                  confirmAction: confirmSubmitAll,
-                  confirmText: t('submitDataConfirmLabel'),
-                  denyText: t('submitDataDenyLabel'),
-                }}
-                button={{
-                  className: styles.mainBodyButton,
-                  label: exportAllUserDataText,
-                }}
-              />
-            ) : null}
-            <ConfirmWindow
-              title={t('deleteNotesConfirmationWindowLabel')}
-              confirmWindow={{
-                confirmAction: confirmDeletion,
-                confirmText: t('deleteNotesConfirmLabel'),
-                denyText: t('deleteNotesDenyLabel'),
-              }}
-              button={{
-                className: styles.mainBodyButton,
-                label: deleteText,
-              }}
-            />
+              <NotesList topicMapItems={allItems} navbarTitle={navbarTitle} />
+            </div>
           </div>
-        </div>
-      </div>
-    </div>
+          <Close className={styles.closeButton} aria-label={t('closeDialog')}>
+            <Cross2Icon />
+          </Close>
+        </Content>
+      </Portal>
+    </Root>
   );
 };

--- a/src/components/Navbar/NotesSection/NotesSection.tsx
+++ b/src/components/Navbar/NotesSection/NotesSection.tsx
@@ -30,15 +30,6 @@ export const NotesSection: React.FC<NotesSectionProps> = ({
     <div className={`${styles.mainBody} ${sizeClassNames}`}>
       <div className={styles.mainBodyContent}>
         <div className={styles.mainBodyTitle}>
-          <Close asChild>
-            <button
-              type="button"
-              className={styles.closeButton}
-              aria-label={t('closeDialog')}
-            >
-              <Cross2Icon />
-            </button>
-          </Close>
           <Title asChild>
             <p>{t('navbarNotesSectionTitle')}</p>
           </Title>

--- a/src/components/TopicMapItem/TopicMapItem.tsx
+++ b/src/components/TopicMapItem/TopicMapItem.tsx
@@ -13,6 +13,7 @@ import { getNoteStateText } from '../../utils/note.utils';
 import { useTranslation } from '../../hooks/useTranslation';
 import { Portal, Root, Trigger } from '@radix-ui/react-dialog';
 import { DialogWindow } from '../Dialog-Window/DialogWindow';
+import { useH5PInstance } from '../../hooks/useH5PInstance';
 
 export type TopicMapItemProps = {
   item: TopicMapItemType;
@@ -26,6 +27,7 @@ export const TopicMapItem: FC<TopicMapItemProps> = ({
   gridRef,
 }) => {
   const { t } = useTranslation();
+  const h5pInstance = useH5PInstance();
   const contentId = useContentId();
   const [userData] = useLocalStorageUserData();
 
@@ -118,7 +120,7 @@ export const TopicMapItem: FC<TopicMapItemProps> = ({
         ) : (
           ''
         )}
-        <Portal>
+        <Portal container={h5pInstance?.containerElement}>
           <DialogWindow item={item} />
         </Portal>
       </Root>

--- a/src/semantics.ts
+++ b/src/semantics.ts
@@ -517,7 +517,7 @@ export const semantics: Readonly<[H5PFieldGroup, H5PBehaviour, H5PL10n]> = [
         label: 'Navbar notes section body',
         name: 'navbarNotesSectionBody',
         default:
-          'Here you have an overview of all the notes you have written. The notes are saved locally in this browser. To save the notes elsewhere, you can print or copy the notes into a document.',
+          'This is an overview of your notes. They are saved locally in this browser. You can either print or copy the notes into a document.',
         type: 'text',
       },
       {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -8,6 +8,7 @@ $h5p-navbar-z-index: 600;
 }
 
 .h5p-topic-map {
+  background-color: var(--theme-color-1);
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
     Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
   font-size: 1rem;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -5,6 +5,8 @@ $h5p-navbar-z-index: 600;
   --notesection-z-index: calc(var(--item-z-index) + 1);
   --overlay-z-index: calc(var(--item-z-index) + 1);
   --dialog-z-index: calc(var(--overlay-z-index) + 1);
+  --confirm-overlay-z-index: calc(var(--dialog-z-index) + 1);
+  --confirm-dialog-z-index: calc(var(--confirm-overlay-z-index) + 1);
 }
 
 .h5p-topic-map {

--- a/src/types/NavbarSections.ts
+++ b/src/types/NavbarSections.ts
@@ -1,4 +1,0 @@
-export enum NavbarSections {
-  TopicMap,
-  Notes,
-}


### PR DESCRIPTION
Improves the accessibility of Topic Map dialog modals (part 2), and converts the notes section into a dialog modal. 

Changes done to modals:
- New close button design: more similar design og the close button as H5Ps Virtual Tour.
- Better scrolling: the whole dialog modal window is now scrollable not only the tabsection (for item modals).
- Better zooming: since scrolling has improved the text inside is more readable when zoomed in. 
- Notes (textarea) has now a min-height to make sure the textarea is accessible when zoomed in. 

Additional:
- Changed the look on the notes section: dark to white. 
- Changed translation for the notes section info text.
- Made the background color fill the whole screen: before the background outside the actual Topic Map was white and noticeable on fullscreen with devtools open or split screen (when Topic Map fullscreen mode didn't actually fill the whole screen). This was done by moving the theme class up to the h5p-topic-map container. 
- Added a hover effect to the buttons inside the confirm modal (i.e. opens when you try to delete all notes). 


Other info: refactored the `noteSection` from `NavBar` to the actual `NoteSection` component to avoid confusion and keep the dialog inside this component instead of `NavBar`.