### PR TITLE
fix: save last character in note textarea

### DIFF
--- a/src/components/Dialog-Window/Notes/DialogNote.tsx
+++ b/src/components/Dialog-Window/Notes/DialogNote.tsx
@@ -93,15 +93,6 @@ export const DialogNote: React.FC<NoteProps> = ({
   React.useEffect(() => {
     // TODO: If this becomes laggy, add a debounce-timer to avoid saving more often than, say, every 100ms.
 
-    if (!userData[contentId]) {
-      userData[contentId] = { dialogs: {} };
-    }
-    if (!userData[contentId]?.dialogs[id]) {
-      userData[contentId].dialogs[id] = {};
-    }
-
-    userData[contentId].dialogs[id].note = note;
-
     if (maxLength) {
       countCharacters();
     }
@@ -119,10 +110,22 @@ export const DialogNote: React.FC<NoteProps> = ({
     contentId,
   ]);
 
+  const handleSetUserData = (note: string): void => {
+    if (!userData[contentId]) {
+      userData[contentId] = { dialogs: {} };
+    }
+    if (!userData[contentId]?.dialogs[id]) {
+      userData[contentId].dialogs[id] = {};
+    }
+
+    userData[contentId].dialogs[id].note = note;
+    setUserData(userData);
+  };
+
   const onChange = (e: React.ChangeEvent<HTMLTextAreaElement>): void => {
     setSavingText();
     setNote(e.target.value);
-    setUserData(userData);
+    handleSetUserData(e.target.value);
   };
 
   return (

--- a/src/components/Dialog-Window/Notes/DialogNote.tsx
+++ b/src/components/Dialog-Window/Notes/DialogNote.tsx
@@ -90,26 +90,6 @@ export const DialogNote: React.FC<NoteProps> = ({
     setCharacterCount(count);
   }, [maxLength, note, savingTextTimeout]);
 
-  React.useEffect(() => {
-    // TODO: If this becomes laggy, add a debounce-timer to avoid saving more often than, say, every 100ms.
-
-    if (maxLength) {
-      countCharacters();
-    }
-    // ensure there's no memory leak on component unmount during timeout
-    return () => {
-      if (savingTextTimeout != null) clearTimeout(savingTextTimeout);
-    };
-  }, [
-    userData,
-    id,
-    note,
-    setUserData,
-    savingTextTimeout,
-    countCharacters,
-    contentId,
-  ]);
-
   const handleSetUserData = (note: string): void => {
     if (!userData[contentId]) {
       userData[contentId] = { dialogs: {} };
@@ -122,10 +102,16 @@ export const DialogNote: React.FC<NoteProps> = ({
     setUserData(userData);
   };
 
-  const onChange = (e: React.ChangeEvent<HTMLTextAreaElement>): void => {
+  const onChange = ({ target }: React.ChangeEvent<HTMLTextAreaElement>): void => {
+    const newValue = target.value;
+
     setSavingText();
-    setNote(e.target.value);
-    handleSetUserData(e.target.value);
+    setNote(newValue);
+    handleSetUserData(newValue);
+
+    if (maxLength) {
+      countCharacters();
+    }
   };
 
   return (


### PR DESCRIPTION
The last character typed was not saved to userData as `userData[contentId].dialogs[id].note = note` was set after `setUserData(userData)`