### PR TITLE
chore: update h5p-types to v5.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "esbuild-runner": "^2.2.2",
         "eslint": "^8.57.0",
         "eslint-config-ndla-h5p": "github:ndlano/eslint-config-ndla-h5p",
-        "h5p-types": "^4.3.0",
+        "h5p-types": "^5.5.0",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
@@ -7882,13 +7882,13 @@
       "license": "MIT"
     },
     "node_modules/h5p-types": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/h5p-types/-/h5p-types-4.3.0.tgz",
-      "integrity": "sha512-sD/+o2H7kQPLqGniF9V1B4AzEklL6OPBDc3HpArDuaVK3sSh4BNGzOgRFMxcJtQrP0fbn2xK+kHS7mmbriiXYQ==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/h5p-types/-/h5p-types-5.5.0.tgz",
+      "integrity": "sha512-nLa096mEzPlJ8LxDxD9vonc6BLmX2L2SBIYzpl3XAVV8aVItWy0WubexkJVjnhxr+NDYxfRCwpjTOG57cuakWQ==",
       "dev": true,
       "dependencies": {
-        "@types/jquery": "^3.5.29",
-        "type-fest": "^4.3.1"
+        "@types/jquery": "^3.5.30",
+        "type-fest": "^4.20.1"
       },
       "peerDependencies": {
         "typescript": ">= 5.0.4"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "esbuild-runner": "^2.2.2",
     "eslint": "^8.57.0",
     "eslint-config-ndla-h5p": "github:ndlano/eslint-config-ndla-h5p",
-    "h5p-types": "^4.3.0",
+    "h5p-types": "^5.5.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",


### PR DESCRIPTION
`h5p-types` v5.5.0 now allows `list` fields to have `widget` property. We can now keep using `widget: none` for some `list` fields in semantics.json